### PR TITLE
Auto-populate cash to close and cap at lesser value

### DIFF
--- a/aha-afc-bonus-calc-capmode-latest/src/App.jsx
+++ b/aha-afc-bonus-calc-capmode-latest/src/App.jsx
@@ -114,7 +114,9 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
     const dpa = computeDPA({ downPayment: baseDown, closingCosts: baseCC });
 
-    const remainingDown = Math.max(0, baseDown - dpa.dpaToDown);
+    const remainingDown = dpaProgram !== "None"
+      ? 0
+      : Math.max(0, baseDown - dpa.dpaToDown);
     let remainingCC = Math.max(0, baseCC - dpa.dpaToCC);
 
     const seller = Math.max(0, toNumber(sellerCreditsInput));

--- a/aha-afc-bonus-calc-capmode-latest/src/App.jsx
+++ b/aha-afc-bonus-calc-capmode-latest/src/App.jsx
@@ -352,11 +352,11 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
           <div className="kv"><span className="label">Buyer Bonus Allowed</span>
             <span className="value">
               ${fmt(data.allowedBonusTotal)}
-              <span className="subtle" style={{marginLeft:8, color:'var(--text-subtle)'}}>({Math.round((data.bonusProgress||0)*100)}% of 1%)</span>
+              <span className="subtle" style={{marginLeft:8, color:'var(--text-subtle)'}}>({((data.bonusProgress||0)*100).toFixed(2)}% of 1%)</span>
             </span>
           </div>
           <div className="progress" style={{margin:'6px 0 8px 0'}}>
-            <div style={{width:`${Math.round((data.bonusProgress||0)*100)}%`}}/>
+            <div style={{width:`${(data.bonusProgress||0)*100}%`}}/>
           </div>
 
           <div className="kv"><span className="label">AFC Contribution (0.375%)</span><span className="value">${fmt(data.allocatedAfc)} ({pct(data.afcAllocPct)})</span></div>
@@ -389,7 +389,7 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
                 `Agent Share (50%): $${fmt(data.agentShare)}`,
                 `AHA Share (50%): $${fmt(data.ahaShare)}`,
                 ``,
-                `Buyer Bonus Allowed: $${fmt(data.allowedBonusTotal)} (${Math.round((data.bonusProgress||0)*100)}% of 1%)`,
+                `Buyer Bonus Allowed: $${fmt(data.allowedBonusTotal)} (${((data.bonusProgress||0)*100).toFixed(2)}% of 1%)`,
                 ` - AFC Contribution: $${fmt(data.allocatedAfc)} (${(data.afcAllocPct*100).toFixed(2)}%)`,
                 ` - AHA Contribution: $${fmt(data.allocatedAha)} (${(data.ahaAllocPct*100).toFixed(2)}%)`,
                 ` - Agent Contribution: $${fmt(data.allocatedAgent)} (${(data.agentAllocPct*100).toFixed(2)}%)`,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -326,7 +326,7 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
               <span>Auto-calc Seller Credits to zero Agent</span>
             </label>
           </div>
-          <input type="text" inputMode="numeric" value={sellerCreditsInput} readOnly={autoSellerCredits} onChange={e=>{
+          <input type="text" inputMode="numeric" value={sellerCreditsInput} onChange={e=>{
             const v=(e.target.value||'').replace(/[^0-9.]/g,'');
             setAutoSellerCredits(false);
             setSellerCreditsInput(v===''? '' : Number(v).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:0}));
@@ -361,7 +361,7 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
 
           <div style={{height:12}} />
           <label>Cash to Close</label>
-          <input type="text" inputMode="numeric" value={cashToCloseInput} readOnly={autoEstimateCTC} onChange={e=>{ const v=(e.target.value||"").replace(/[^0-9.]/g,""); setAutoEstimateCTC(false); setCashToCloseInput(v===""? "" : Number(v).toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0})); }} onKeyDown={blurOnEnter} />
+          <input type="text" inputMode="numeric" value={cashToCloseInput} onChange={e=>{ const v=(e.target.value||"").replace(/[^0-9.]/g,""); setAutoEstimateCTC(false); setCashToCloseInput(v===""? "" : Number(v).toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0})); }} onKeyDown={blurOnEnter} />
           <div className="small">
             Auto ON: field auto-populates from CTC after DPA (before seller/other credits).
             Auto OFF: manually enter Cash to Close; cap uses the lesser of Program Cap and this amount.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,7 +130,9 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
     const dpa = computeDPA({ downPayment: baseDown, closingCosts: paddedCC });
 
-    const remainingDown = Math.max(0, baseDown - dpa.dpaToDown);
+    const remainingDown = dpaProgram !== "None"
+      ? 0
+      : Math.max(0, baseDown - dpa.dpaToDown);
     const preCreditCC = Math.max(0, paddedCC - dpa.dpaToCC);
 
     const seller = Math.max(0, toNumber(sellerCreditsInput));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -144,7 +144,8 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     let remainingCC = Math.max(0, preCreditCC - seller - other);
     const netBeforeEarnest = remainingDown + remainingCC + minGap;
     const ctcNetCalc = Math.max(0, netBeforeEarnest - (includeEarnestInCTC ? earnest : 0));
-    const ctcNet = Math.max(dpa.minBorrower, ctcNetCalc);
+    // Round cash-to-close to whole dollars for stability
+    const ctcNet = Math.round(Math.max(dpa.minBorrower, ctcNetCalc));
     const ctcBase = Math.max(0, baseDown + paddedCC);
     const displayCC = paddedCC + minGap;
 
@@ -163,7 +164,8 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
     // Credits needed (seller/other/DPA toward cap) to reduce Agent contribution to $0:
     // When remainingNeed <= afcPlanned + ahaPlanned, agent allocation falls to zero.
-    const creditsToZeroAgent = Math.max(0, (Number(capUsed)||0) - ((Number(afcPlanned)||0) + (Number(ahaPlanned)||0)));
+    // Round needed credits to whole dollars to prevent oscillation
+    const creditsToZeroAgent = Math.max(0, Math.round((Number(capUsed)||0) - ((Number(afcPlanned)||0) + (Number(ahaPlanned)||0))));
 
     const agentNet = agentShare - allocatedAgent;
     const ahaNet = ahaShare - allocatedAha;
@@ -203,16 +205,19 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     if(autoSellerCredits){
       const other = Math.max(0, toNumber(otherCreditsInput));
       const dpaCreds = dpaCountsTowardCap ? (data.dpaToDown + data.dpaToCC) : 0;
-      const needed = Math.max(0, data.creditsToZeroAgent - other - dpaCreds);
-      const formatted = toCurrency(needed);
-      if(sellerCreditsInput!==formatted) setSellerCreditsInput(formatted);
+      const needed = Math.max(0, Math.round(data.creditsToZeroAgent - other - dpaCreds));
+      if(toNumber(sellerCreditsInput) !== needed){
+        setSellerCreditsInput(toCurrency(needed));
+      }
     }
   },[autoSellerCredits, otherCreditsInput, dpaCountsTowardCap, data.dpaToDown, data.dpaToCC, data.creditsToZeroAgent, sellerCreditsInput]);
 
   useEffect(()=>{
     if(autoEstimateCTC){
-      const formatted = toCurrency(data.ctcNet);
-      if(cashToCloseInput!==formatted) setCashToCloseInput(formatted);
+      const needed = Math.max(0, Math.round(data.ctcNet));
+      if(toNumber(cashToCloseInput) !== needed){
+        setCashToCloseInput(toCurrency(needed));
+      }
     }
   },[autoEstimateCTC, data.ctcNet, cashToCloseInput]);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,6 +192,22 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
   },[priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, programCap.amount, autoEstimateCTC, downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, dpaProgram, dpaMode, dpaAmountInput, dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
 
   useEffect(()=>{
+    if(autoSellerCredits){
+      const other = Math.max(0, toNumber(otherCreditsInput));
+      const dpaCreds = dpaCountsTowardCap ? (data.dpaToDown + data.dpaToCC) : 0;
+      const baseCtc = data.ctcNet + data.seller + other;
+      const planned = data.price * 0.0075;
+      let needed = programCap.amount - planned - other - dpaCreds;
+      if(!(programCap.amount <= baseCtc - needed - other)){
+        needed = (baseCtc - 2*other - dpaCreds - planned)/2;
+      }
+      needed = Math.max(0, needed);
+      const formatted = toCurrency(needed);
+      if(sellerCreditsInput!==formatted) setSellerCreditsInput(formatted);
+    }
+  },[autoSellerCredits, otherCreditsInput, dpaCountsTowardCap, data.dpaToDown, data.dpaToCC, data.ctcNet, data.seller, data.price, programCap.amount, sellerCreditsInput]);
+
+  useEffect(()=>{
     if(autoEstimateCTC){
       const formatted = toCurrency(data.ctcNet);
       if(cashToCloseInput!==formatted) setCashToCloseInput(formatted);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -416,11 +416,11 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
           <div className="kv"><span className="label">Buyer Bonus Allowed</span>
             <span className="value">
               ${fmt(data.allowedBonusTotal)}
-              <span className="subtle" style={{marginLeft:8, color:'var(--text-subtle)'}}>({Math.round((data.bonusProgress||0)*100)}% of 1%)</span>
+              <span className="subtle" style={{marginLeft:8, color:'var(--text-subtle)'}}>({((data.bonusProgress||0)*100).toFixed(2)}% of 1%)</span>
             </span>
           </div>
           <div className="progress" style={{margin:'6px 0 8px 0'}}>
-            <div style={{width:`${Math.round((data.bonusProgress||0)*100)}%`}}/>
+            <div style={{width:`${(data.bonusProgress||0)*100}%`}}/>
           </div>
 
           <div className="kv"><span className="label">AFC Contribution (0.375%)</span><span className="value">${fmt(data.allocatedAfc)} ({pct(data.afcAllocPct)})</span></div>
@@ -453,7 +453,7 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
                 `Agent Share (50%): $${fmt(data.agentShare)}`,
                 `AHA Share (50%): $${fmt(data.ahaShare)}`,
                 ``,
-                `Buyer Bonus Allowed: $${fmt(data.allowedBonusTotal)} (${Math.round((data.bonusProgress||0)*100)}% of 1%)`,
+                `Buyer Bonus Allowed: $${fmt(data.allowedBonusTotal)} (${((data.bonusProgress||0)*100).toFixed(2)}% of 1%)`,
                 ` - AFC Contribution: $${fmt(data.allocatedAfc)} (${(data.afcAllocPct*100).toFixed(2)}%)`,
                 ` - AHA Contribution: $${fmt(data.allocatedAha)} (${(data.ahaAllocPct*100).toFixed(2)}%)`,
                 ` - Agent Contribution: $${fmt(data.allocatedAgent)} (${(data.agentAllocPct*100).toFixed(2)}%)`,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -155,14 +155,14 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     // Cap uses the lesser of the Program Cap and Cash to Close.
     const cashToClose = autoEstimateCTC ? ctcNet : ctcManual;
 
-    const preCredits = (seller + other) + (dpaCountsTowardCap ? (dpa.dpaToDown + dpa.dpaToCC) : 0);
+    const preCredits = seller + (dpaCountsTowardCap ? (dpa.dpaToDown + dpa.dpaToCC) : 0);
 
     const capUsed = Math.min(baseCap, cashToClose);
 
     const alloc = allocation({ price, commissionRate: commRate, capAmount: capUsed, sellerCredits: preCredits });
     const { grossCommission, agentShare, ahaShare, allocatedAfc, allocatedAha, allocatedAgent, allowed, afcPlanned, ahaPlanned, agentPlanned } = alloc;
 
-    // Credits needed (seller/other/DPA toward cap) to reduce Agent contribution to $0:
+    // Credits needed (seller/DPA toward cap) to reduce Agent contribution to $0:
     // When remainingNeed <= afcPlanned + ahaPlanned, agent allocation falls to zero.
     // Round needed credits to whole dollars to prevent oscillation
     const creditsToZeroAgent = Math.max(0, Math.round((Number(capUsed)||0) - ((Number(afcPlanned)||0) + (Number(ahaPlanned)||0))));
@@ -213,11 +213,11 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     if(autoEstimateCTC){
       const preNet = data.ctcAfterDpa;
       const Cprime = Math.max(0, preNet - other);
-      const maxSeller = Math.max(0, Cprime - minBorrower);
+      const maxSeller = Math.max(0, preNet - minBorrower);
 
-      let sellerNeeded = Math.max(0, baseCap - planned - other - dpaCreds);
-      if(sellerNeeded > Cprime - baseCap){
-        sellerNeeded = Math.max(0, (Cprime - planned - other - dpaCreds) / 2);
+      let sellerNeeded = Math.max(0, baseCap - planned - dpaCreds);
+      if(sellerNeeded > preNet - baseCap){
+        sellerNeeded = Math.max(0, (preNet - planned - dpaCreds) / 2);
       }
       sellerNeeded = Math.min(maxSeller, Math.round(sellerNeeded));
 
@@ -236,8 +236,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     } else if(autoSellerCredits){
       const cashManual = Math.max(0, toNumber(cashToCloseInput));
       const capUsed = Math.min(baseCap, cashManual);
-      const totalOther = other + dpaCreds;
-      const needed = Math.max(0, Math.round(capUsed - planned - totalOther));
+      const needed = Math.max(0, Math.round(capUsed - planned - dpaCreds));
       const maxSeller = Math.max(0, cashManual - minBorrower);
       const sellerNeeded = Math.min(maxSeller, needed);
       if(toNumber(sellerCreditsInput) !== sellerNeeded){

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -126,7 +126,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
       : price * (Math.max(0, Number(digitsOnly(downPctInput)||"0"))/100);
     const baseCC = price * (Math.max(0, Number(digitsOnly(closingCostPctInput)||"0"))/100);
     const ccPadPct = Math.max(0, Number(digitsOnly(closingCostPadPctInput)||"0"))/100;
-    const paddedCC = baseCC * (1 + ccPadPct);
+    const paddedCC = baseCC + price * ccPadPct;
 
     const dpa = computeDPA({ downPayment: baseDown, closingCosts: paddedCC });
 
@@ -136,7 +136,6 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     const seller = Math.max(0, toNumber(sellerCreditsInput));
     const other = Math.max(0, toNumber(otherCreditsInput));
     const earnest = Math.max(0, toNumber(earnestMoneyInput));
-
     const minGap = Math.max(0, dpa.minBorrower - (remainingDown + preCreditCC));
     const preCreditCTC = remainingDown + preCreditCC + minGap;
     const ctcAfterDpa = Math.max(0, preCreditCTC - (includeEarnestInCTC ? earnest : 0));
@@ -170,37 +169,40 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
     const agentNet = agentShare - allocatedAgent;
     const ahaNet = ahaShare - allocatedAha;
 
+    const capConsumed = capUsed ?? (allowed + seller);
     const onePct = price * 0.01 || 1;
-    const bonusProgress = Math.max(0, Math.min(1, allowed / onePct));
+    const bonusProgress = Math.max(0, Math.min(1, capConsumed / onePct));
 
-      return {
-        price,
-        commissionPct: Math.max(0, Number(digitsOnly(commissionPctInput)||"0")),
-        grossCommission, agentShare, ahaShare,
-        allocatedAfc, allocatedAha, allocatedAgent,
-        afcAllocPct: price? allocatedAfc/price : 0,
-        ahaAllocPct: price? allocatedAha/price : 0,
-        agentAllocPct: price? allocatedAgent/price : 0,
-        agentNet, ahaNet,
-        afcPlanned, ahaPlanned, agentPlanned,
-        allowedBonusTotal: allowed, capUsed,
-        earnest, includeEarnestInCTC, dpaCountsTowardCap,
-        buyerCreditPct: price? Math.max(0, Math.min(1, allowed/price)) : 0,
+    return {
+      price,
+      commissionPct: Math.max(0, Number(digitsOnly(commissionPctInput)||"0")),
+      grossCommission, agentShare, ahaShare,
+      allocatedAfc, allocatedAha, allocatedAgent,
+      afcAllocPct: price? allocatedAfc/price : 0,
+      ahaAllocPct: price? allocatedAha/price : 0,
+      agentAllocPct: price? allocatedAgent/price : 0,
+      agentNet, ahaNet,
+      afcPlanned, ahaPlanned, agentPlanned,
+      allowedBonusTotal: allowed, capUsed, bonusProgress,
+      earnest, includeEarnestInCTC, dpaCountsTowardCap,
+      buyerCreditPct: price? Math.max(0, Math.min(1, allowed/price)) : 0,
 
-        creditsToZeroAgent,
-        downPayment: baseDown,
-        closingCosts: displayCC,
-        seller, other,
-        dpaProgram, dpaMode,
-        dpaToDown: dpa.dpaToDown, dpaToCC: dpa.dpaToCC, dpaUnused: dpa.dpaUnused,
-        dpaRequested: dpa.dpaRequested, dpaMaxByProgram: dpa.dpaMaxByProgram,
-        dpaMinBorrower: dpa.minBorrower,
-        ruleLabel: programCap.ruleLabel,
-        ctcAfterDpa,
-        ctcNet,
-        ctcBase,
-      };
-      },[priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, programCap.amount, autoEstimateCTC, downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, closingCostPadPctInput, dpaProgram, dpaMode, dpaAmountInput, dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
+      creditsToZeroAgent,
+      downPayment: baseDown,
+      closingCosts: displayCC,
+      seller, other,
+      dpaProgram, dpaMode,
+      dpaToDown: dpa.dpaToDown, dpaToCC: dpa.dpaToCC, dpaUnused: dpa.dpaUnused,
+      dpaRequested: dpa.dpaRequested, dpaMaxByProgram: dpa.dpaMaxByProgram,
+      dpaMinBorrower: dpa.minBorrower,
+      ruleLabel: programCap.ruleLabel,
+      ctcAfterDpa,
+      ctcNet,
+      ctcBase,
+    };
+  }, [priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, programCap.amount, autoEstimateCTC,
+      downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, closingCostPadPctInput, dpaProgram, dpaMode, dpaAmountInput,
+      dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
 
   useEffect(()=>{
     if(!autoSellerCredits && !autoEstimateCTC) return;
@@ -243,8 +245,8 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
         setSellerCreditsInput(toCurrency(sellerNeeded));
       }
     }
-  },[autoSellerCredits, autoEstimateCTC, otherCreditsInput, sellerCreditsInput, cashToCloseInput, dpaCountsTowardCap, data.dpaToDown, data.dpaToCC, data.ctcAfterDpa, data.afcPlanned, data.ahaPlanned, programCap.amount, data.dpaMinBorrower]);
-
+  },[autoSellerCredits, autoEstimateCTC, otherCreditsInput, sellerCreditsInput, cashToCloseInput, dpaCountsTowardCap, data.dpaToDown,
+      data.dpaToCC, data.ctcAfterDpa, data.afcPlanned, data.ahaPlanned, programCap.amount, data.dpaMinBorrower]);
 const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e.target.value); };
   const handleDownAmtChange = (e)=>{
     setDpLastEdited('dollars');
@@ -373,9 +375,14 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
             const v=(e.target.value||'').replace(/[^0-9.]/g,'');
             setOtherCreditsInput(v===''? '' : Number(v).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:0}));
           }} onKeyDown={blurOnEnter} />
-
-          <div style={{height:12}} />
-          <label>Closing Cost Padding (%)</label>
+            <div style={{height:12}} />
+            <label>Earnest Money</label>
+            <input type="text" inputMode="numeric" value={earnestMoneyInput} onChange={e=>{
+              const v=(e.target.value||'').replace(/[^0-9.]/g,'');
+              setEarnestMoneyInput(v===''? '' : Number(v).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:0}));
+            }} onKeyDown={blurOnEnter} />
+            <div style={{height:12}} />
+            <label>Closing Cost Padding (%)</label>
           <input type="text" inputMode="decimal" value={closingCostPadPctInput} onChange={e=>setClosingCostPadPctInput(e.target.value)} onKeyDown={blurOnEnter} />
           <div className="small">Adds extra % buffer to closing costs.</div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,9 +58,22 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
   const digitsOnly = (s) => (s||"").replace(/[^0-9.]/g,"");
   const toNumber = (v) => { if(v===""||v==null) return 0; const n=Number(digitsOnly(v)); return Number.isFinite(n)? n : 0; };
-  const toCurrency = (n) => Number(n).toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0});
-  const fmt = (n) => Number(n).toLocaleString(undefined,{maximumFractionDigits:2,minimumFractionDigits:2});
-  const pct = (n) => (n*100).toFixed(2)+"%";
+  const toCurrency = (n) => {
+    const num = Number(n);
+    return Number.isFinite(num)
+      ? num.toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0})
+      : "$0";
+  };
+  const fmt = (n) => {
+    const num = Number(n);
+    return Number.isFinite(num)
+      ? num.toLocaleString(undefined,{maximumFractionDigits:2,minimumFractionDigits:2})
+      : "0.00";
+  };
+  const pct = (n) => {
+    const num = Number(n);
+    return Number.isFinite(num) ? (num*100).toFixed(2)+"%" : "0.00%";
+  };
   const blurOnEnter = (e)=>{ if(e.key==='Enter') e.currentTarget.blur(); };
 
   const priceNum = useMemo(()=>toNumber(homePriceInput),[homePriceInput]);
@@ -290,10 +303,6 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
                 }} onKeyDown={blurOnEnter} />
                 <div className="small">Defaults: CHFA $1,000; Essex $0 (editable).</div>
               </div>
-              <div style={{display:'flex',flexDirection:'column',gap:8}}>
-                <label className="row"><input type="checkbox" checked={dpaAllowCC} onChange={e=>setDpaAllowCC(e.target.checked)} /> <span style={{marginLeft:8}}>Allow leftover to Closing Costs</span></label>
-                <label className="row"><input type="checkbox" checked={dpaCountsTowardCap} onChange={e=>setDpaCountsTowardCap(e.target.checked)} /> <span style={{marginLeft:8}}>Count DPA toward Program Cap (rare)</span></label>
-              </div>
             </div>
           </div>
 
@@ -317,38 +326,33 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
             const v=(e.target.value||'').replace(/[^0-9.]/g,'');
             setOtherCreditsInput(v===''? '' : Number(v).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:0}));
           }} onKeyDown={blurOnEnter} />
-<div style={{height:12}} />
-<div className="row" style={{gap:12, alignItems:'center', flexWrap:'wrap'}}>
-  <label className="row">
-    <input type="checkbox" checked={includeEarnestInCTC} onChange={e=>setIncludeEarnestInCTC(e.target.checked)} />
-    <span style={{marginLeft:6}}>Include Earnest Money in Net CTC</span>
-  </label>
-  <label className="row">
-    <input type="checkbox" checked={dpaCountsTowardCap} onChange={e=>setDpaCountsTowardCap(e.target.checked)} />
-    <span style={{marginLeft:6}}>Count DPA toward Cap</span>
-  </label>
-</div>
 
-<div style={{height:12}} />
-<div className="row" style={{gap:8, alignItems:'center', flexWrap:'wrap'}}>
-  <div style={{flex:1}}>
-    <div className="row" style={{justifyContent:'space-between', alignItems:'center'}}>
-                <label>Cash to Close</label>
-                <label className="row" style={{gap:6}}>
-                  <input type="checkbox" checked={autoEstimateCTC} onChange={e=>setAutoEstimateCTC(e.target.checked)} />
-                  <span>Auto-calc Cash to Close</span>
-                </label>
-              </div>
-              <input type="text" inputMode="numeric" value={cashToCloseInput} readOnly={autoEstimateCTC} onChange={e=>{ const v=(e.target.value||"").replace(/[^0-9.]/g,""); setAutoEstimateCTC(false); setCashToCloseInput(v===""? "" : Number(v).toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0})); }} onKeyDown={blurOnEnter} />
-              <div className="small">
-                Auto ON: field auto-populates from Net CTC (includes DPA and credits).
-                Auto OFF: manually enter Cash to Close; cap uses the lesser of Program Cap and this amount.
-              </div>
-            </div>
-            <label className="row card" style={{padding:'8px 10px', borderRadius:12}}>
+          <div style={{height:12}} />
+          <div className="row" style={{gap:12, alignItems:'center', flexWrap:'wrap'}}>
+            <label className="row">
               <input type="checkbox" checked={autoEstimateCTC} onChange={e=>setAutoEstimateCTC(e.target.checked)} />
-              <span style={{marginLeft:8}}>Auto</span>
+              <span style={{marginLeft:6}}>Auto-calc Cash to Close</span>
             </label>
+            <label className="row">
+              <input type="checkbox" checked={dpaAllowCC} onChange={e=>setDpaAllowCC(e.target.checked)} />
+              <span style={{marginLeft:6}}>Allow leftover to Closing Costs</span>
+            </label>
+            <label className="row">
+              <input type="checkbox" checked={dpaCountsTowardCap} onChange={e=>setDpaCountsTowardCap(e.target.checked)} />
+              <span style={{marginLeft:6}}>Count DPA toward Cap</span>
+            </label>
+            <label className="row">
+              <input type="checkbox" checked={includeEarnestInCTC} onChange={e=>setIncludeEarnestInCTC(e.target.checked)} />
+              <span style={{marginLeft:6}}>Include Earnest Money in Net CTC</span>
+            </label>
+          </div>
+
+          <div style={{height:12}} />
+          <label>Cash to Close</label>
+          <input type="text" inputMode="numeric" value={cashToCloseInput} readOnly={autoEstimateCTC} onChange={e=>{ const v=(e.target.value||"").replace(/[^0-9.]/g,""); setAutoEstimateCTC(false); setCashToCloseInput(v===""? "" : Number(v).toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0})); }} onKeyDown={blurOnEnter} />
+          <div className="small">
+            Auto ON: field auto-populates from Net CTC (includes DPA and credits).
+            Auto OFF: manually enter Cash to Close; cap uses the lesser of Program Cap and this amount.
           </div>
         </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
   const [homePriceInput, setHomePriceInput] = useState("$400,000");
   const [commissionPctInput, setCommissionPctInput] = useState("2.5");
   const [sellerCreditsInput, setSellerCreditsInput] = useState("$0");
-  const [autoSellerCredits, setAutoSellerCredits] = useState(true);
+  const [autoSellerCredits, setAutoSellerCredits] = useState(false);
   const [otherCreditsInput, setOtherCreditsInput] = useState("$0");
   const [cashToCloseInput, setCashToCloseInput] = useState("$0");
 
@@ -34,7 +34,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
   const [closingCostPadPctInput, setClosingCostPadPctInput] = useState("3");
 
   // Auto cash to close
-  const [autoEstimateCTC, setAutoEstimateCTC] = useState(true);
+  const [autoEstimateCTC, setAutoEstimateCTC] = useState(false);
 
   // DPA
   const [dpaProgram, setDpaProgram] = useState("None"); // None | CHFA | Essex | Custom

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -202,9 +202,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
       ctcNet,
       ctcBase,
     };
-  }, [priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, programCap.amount, autoEstimateCTC,
-      downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, closingCostPadPctInput, dpaProgram, dpaMode, dpaAmountInput,
-      dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
+  }, [priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, earnestMoneyInput, includeEarnestInCTC, cashToCloseInput, programCap.amount, autoEstimateCTC, downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, closingCostPadPctInput, dpaProgram, dpaMode, dpaAmountInput, dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
 
   useEffect(()=>{
     if(!autoSellerCredits && !autoEstimateCTC) return;
@@ -247,8 +245,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
         setSellerCreditsInput(toCurrency(sellerNeeded));
       }
     }
-  },[autoSellerCredits, autoEstimateCTC, otherCreditsInput, sellerCreditsInput, cashToCloseInput, dpaCountsTowardCap, data.dpaToDown,
-      data.dpaToCC, data.ctcAfterDpa, data.afcPlanned, data.ahaPlanned, programCap.amount, data.dpaMinBorrower]);
+  }, [autoSellerCredits, autoEstimateCTC, otherCreditsInput, sellerCreditsInput, cashToCloseInput, dpaCountsTowardCap, data.dpaToDown, data.dpaToCC, data.ctcAfterDpa, data.afcPlanned, data.ahaPlanned, programCap.amount, data.dpaMinBorrower]);
 const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e.target.value); };
   const handleDownAmtChange = (e)=>{
     setDpLastEdited('dollars');
@@ -385,8 +382,8 @@ const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e
             }} onKeyDown={blurOnEnter} />
             <div style={{height:12}} />
             <label>Closing Cost Padding (%)</label>
-          <input type="text" inputMode="decimal" value={closingCostPadPctInput} onChange={e=>setClosingCostPadPctInput(e.target.value)} onKeyDown={blurOnEnter} />
-          <div className="small">Adds extra % buffer to closing costs.</div>
+            <input type="text" inputMode="decimal" value={closingCostPadPctInput} onChange={e=>setClosingCostPadPctInput(e.target.value)} onKeyDown={blurOnEnter} />
+            <div className="small">Adds extra % buffer to closing costs.</div>
 
           <div style={{height:12}} />
           <div className="row" style={{gap:12, alignItems:'center', flexWrap:'wrap'}}>


### PR DESCRIPTION
## Summary
- Auto-fill cash to close using computed net amount
- Limit cap to the lesser of program cap and cash to close

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a17a831c4483278be40afa3dfc6675