### PR TITLE
Include DPA minimum borrower requirement in cash to close

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,16 +114,17 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
     const dpa = computeDPA({ downPayment: baseDown, closingCosts: baseCC });
 
+    const minBorrower = dpa.minBorrower;
     const remainingDown = Math.max(0, baseDown - dpa.dpaToDown);
-    let remainingCC = Math.max(0, baseCC - dpa.dpaToCC);
+    const displayCC = Math.max(0, baseCC - dpa.dpaToCC) + minBorrower;
 
     const seller = Math.max(0, toNumber(sellerCreditsInput));
     const other = Math.max(0, toNumber(otherCreditsInput));
-    remainingCC = Math.max(0, remainingCC - seller - other);
 
+    const preCreditCTC = remainingDown + displayCC;
     const earnest = Math.max(0, toNumber(earnestMoneyInput));
-    const ctcNet = Math.max(0, remainingDown + remainingCC - (includeEarnestInCTC ? earnest : 0));
-    const ctcBase = Math.max(0, baseDown + baseCC);
+    const ctcNet = Math.max(0, preCreditCTC - seller - other - (includeEarnestInCTC ? earnest : 0));
+    const ctcBase = Math.max(0, baseDown + baseCC + minBorrower);
 
     const ctcManual = Math.max(0, toNumber(cashToCloseInput));
     const baseCap = Math.max(0, programCap.amount);
@@ -165,7 +166,8 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
       allowedBonusTotal: allowed, capUsed,
       earnest, includeEarnestInCTC, dpaCountsTowardCap,
       buyerCreditPct: price? Math.max(0, Math.min(1, allowed/price)) : 0,
-      
+
+      preCreditCTC, ctcNet, ctcBase, displayCC,
       creditsToZeroAgent,
       downPayment: baseDown,
       closingCosts: baseCC,


### PR DESCRIPTION
## Summary
- Account for DPA minimum borrower requirement when calculating pre-credit cash to close and closing costs
- Expose updated cash-to-close figures in computed data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3ed373cd083279f1f5c0e35116da2