### PR TITLE
Set remaining down to zero when DPA program selected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,7 +114,7 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
 
     const dpa = computeDPA({ downPayment: baseDown, closingCosts: baseCC });
 
-    const remainingDown = Math.max(0, baseDown - dpa.dpaToDown);
+    const remainingDown = dpaProgram !== "None" ? 0 : Math.max(0, baseDown - dpa.dpaToDown);
     let remainingCC = Math.max(0, baseCC - dpa.dpaToCC);
 
     const seller = Math.max(0, toNumber(sellerCreditsInput));


### PR DESCRIPTION
## Summary
- Zero-out remaining down payment when a DPA program is chosen, letting assistance fully cover the down payment.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3ed13c034832796c2d1d4a0fe20dd