### PR TITLE
fix undefined dpaMode reference

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -198,7 +198,8 @@ dark? r.classList.add('dark') : r.classList.remove('dark'); },[dark]);
       ctcBase,
     };
     
-    },[priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, earnestMoneyInput, includeEarnestInCTC, programCap.amount, autoEstimateCTC, downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, dpaProgram, dpaMode, dpaAmountInput, dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
+    // dpaMode intentionally omitted to prevent undefined reference
+    },[priceNum, commissionPctInput, sellerCreditsInput, otherCreditsInput, cashToCloseInput, earnestMoneyInput, includeEarnestInCTC, programCap.amount, autoEstimateCTC, downPctInput, downAmtInput, dpLastEdited, closingCostPctInput, dpaProgram, dpaAmountInput, dpaMaxPctInput, dpaMinBorrowerInput, dpaAllowCC, dpaCountsTowardCap, loanType, occupancy]);
 
 const handleDownPctChange = (e)=>{ setDpLastEdited('percent'); setDownPctInput(e.target.value); };
   const handleDownAmtChange = (e)=>{


### PR DESCRIPTION
## Summary
- remove undefined `dpaMode` from `useMemo` dependency list to prevent runtime errors
- document that `dpaMode` was intentionally removed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a51211f8208327b41bedfab2cd5b4d